### PR TITLE
Set JSON content type in request headers

### DIFF
--- a/request.go
+++ b/request.go
@@ -153,6 +153,7 @@ func WithBody[T any](body T) func(*RequestConfiguration) {
 		}
 
 		r.Body = jsonBody
+		r.Headers["Content-Type"] = "application/json"
 	}
 }
 


### PR DESCRIPTION
The change made to request.go ensures the content-type in the request headers is set to 'application/json'. This ensures correct interpretation of the request body by servers expecting JSON content.