### PR TITLE
Add getResponse struct and update test cases

### DIFF
--- a/request.go
+++ b/request.go
@@ -59,9 +59,11 @@ func do[T any](method Method, url string, options ...func(*RequestConfiguration)
 		request.Header.Set(key, value)
 	}
 
+	values := request.URL.Query()
 	for key, value := range requestConfig.Parameters {
-		request.URL.Query().Add(key, value)
+		values.Add(key, value)
 	}
+	request.URL.RawQuery = values.Encode()
 
 	for key, value := range requestConfig.Cookies {
 		request.AddCookie(&http.Cookie{Name: key, Value: value})

--- a/request_test.go
+++ b/request_test.go
@@ -15,7 +15,41 @@ type getJsonResponse struct {
 	} `json:"slideshow"`
 }
 
+type getResponse struct {
+	Args    map[string]string `json:"args"`
+	Headers struct {
+		Accept          string `json:"Accept"`
+		AcceptEncoding  string `json:"Accept-Encoding"`
+		AcceptLanguage  string `json:"Accept-Language"`
+		Dnt             string `json:"Dnt"`
+		Host            string `json:"Host"`
+		Priority        string `json:"Priority"`
+		Referer         string `json:"Referer"`
+		SecChUa         string `json:"Sec-Ch-Ua"`
+		SecChUaMobile   string `json:"Sec-Ch-Ua-Mobile"`
+		SecChUaPlatform string `json:"Sec-Ch-Ua-Platform"`
+		SecFetchDest    string `json:"Sec-Fetch-Dest"`
+		SecFetchMode    string `json:"Sec-Fetch-Mode"`
+		SecFetchSite    string `json:"Sec-Fetch-Site"`
+		UserAgent       string `json:"User-Agent"`
+		XAmznTraceId    string `json:"X-Amzn-Trace-Id"`
+	} `json:"headers"`
+	Origin string `json:"origin"`
+	Url    string `json:"url"`
+}
+
 func TestGet(t *testing.T) {
+	response, err := Get[getResponse]("https://httpbin.org/get", WithParameter("key", "value"))
+	if err != nil {
+		t.Errorf("failed to get JSON: %v", err)
+	}
+
+	if response.Args["key"] != "value" {
+		t.Errorf("expected key to be 'value', got %s", response.Args["key"])
+	}
+}
+
+func TestGet_JSON(t *testing.T) {
 	response, err := Get[getJsonResponse]("https://httpbin.org/json")
 	if err != nil {
 		t.Errorf("failed to get JSON: %v", err)


### PR DESCRIPTION
A new structure, getResponse, has been introduced to capture complete response data. This includes arguments, headers, origin, and url. Corresponding changes have been made in the TestGet test case. Also, improved management of request configuration parameters in the request module by encoding them within URL's raw query string.