### PR TITLE
Improve error handling in JSON decoding

### DIFF
--- a/request.go
+++ b/request.go
@@ -87,6 +87,9 @@ func do[T any](method Method, url string, options ...func(*RequestConfiguration)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		if unmarshalErr, ok := err.(*json.UnmarshalTypeError); ok {
+			return result, &Error{Message: fmt.Sprintf("failed to decode field \"%s\"", unmarshalErr.Field)}
+		}
 		return result, &Error{Message: "failed to decode response"}
 	}
 


### PR DESCRIPTION
Added specific error handling for UnmarshalTypeError in the JSON decoding process in request.go. Now, if the error is of this type, a more informative error message will be returned, specifying the field that caused the decoding failure.